### PR TITLE
Support getting details for unauthenticated users

### DIFF
--- a/src/Concerns/HasTruckspaceAttributes.php
+++ b/src/Concerns/HasTruckspaceAttributes.php
@@ -13,7 +13,7 @@ trait HasTruckspaceAttributes
      */
     public function getUsernameAttribute(): ?string
     {
-        return Walkway::user()->getUsername();
+        return Walkway::user($this)->getUsername();
     }
 
     /**
@@ -23,7 +23,7 @@ trait HasTruckspaceAttributes
      */
     public function getProfilePhotoAttribute(): ?string
     {
-        return Walkway::user()->getProfilePhoto();
+        return Walkway::user($this)->getProfilePhoto();
     }
 
     /**
@@ -33,7 +33,7 @@ trait HasTruckspaceAttributes
      */
     public function getCoverPhotoAttribute(): ?string
     {
-        return Walkway::user()->getCoverPhoto();
+        return Walkway::user($this)->getCoverPhoto();
     }
 
     /**
@@ -43,7 +43,7 @@ trait HasTruckspaceAttributes
      */
     public function getSteamIdAttribute(): ?int
     {
-        return Walkway::user()->getSteamId();
+        return Walkway::user($this)->getSteamId();
     }
 
     /**
@@ -53,6 +53,6 @@ trait HasTruckspaceAttributes
      */
     public function getDiscordIdAttribute(): ?int
     {
-        return Walkway::user()->getDiscordId();
+        return Walkway::user($this)->getDiscordId();
     }
 }

--- a/src/Walkway.php
+++ b/src/Walkway.php
@@ -32,7 +32,7 @@ class Walkway
             $model = Auth::user();
         }
 
-        if (! $model && Auth::user()) {
+        if (! $model && ! Auth::check()) {
             return null;
         }
 

--- a/src/Walkway.php
+++ b/src/Walkway.php
@@ -2,6 +2,7 @@
 
 namespace Truckspace\Walkway;
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Auth;
 use Truckspace\Walkway\Models\User;
 use Truckspace\Walkway\Services\TruckspaceService;
@@ -22,15 +23,20 @@ class Walkway
     /**
      * Get the logged in users Truckspace details.
      *
+     * @param  Model|null  $model
      * @return User|null
      */
-    public static function user(): ?User
+    public static function user(?Model $model = null): ?User
     {
-        if (! Auth::check()) {
+        if (! $model && Auth::check()) {
+            $model = Auth::user();
+        }
+
+        if (! $model && Auth::user()) {
             return null;
         }
 
-        $user = TruckspaceService::getUser();
+        $user = TruckspaceService::getUser($model);
 
         return (new User($user));
     }


### PR DESCRIPTION
Currently, we are only able to get details for the authenticated users, but there may be a few situations where we need to get the users details when they're not logged in.

For example, on a blog page we way show the author but we are unable to get the users information.

This also allows people to pass an instance of a user into the `Walkway::user()` method.