### PR TITLE
Add the ability to fake the response from the user model

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
     "require": {
         "php": "^7.4",
         "ext-json": "*",
+        "fzaninotto/faker": "^1.9",
         "illuminate/support": "^8.7",
         "laravel/socialite": "^5.0"
     },

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -2,6 +2,8 @@
 
 namespace Truckspace\Walkway\Models;
 
+use Faker\Factory;
+
 class User
 {
     /**
@@ -46,10 +48,21 @@ class User
      * Create a new User instance.
      *
      * @param  array|null  $user
-     * @return void
+     * @param  bool  $fake
      */
-    public function __construct(?array $user)
+    public function __construct(?array $user, bool $fake = false)
     {
+        if ($fake) {
+            $faker = Factory::create();
+
+            $this->id = $faker->randomNumber();
+            $this->username = $faker->userName;
+            $this->profilePhoto = $faker->imageUrl();
+            $this->coverPhoto = $faker->imageUrl();
+            $this->steamId = '765' . $faker->randomNumber(7, true) . $faker->randomNumber(7, true);;
+            $this->discordId = $faker->randomNumber();
+        }
+
         if ($user) {
             $this->id = $user['id'];
             $this->username = $user['username'];

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -59,7 +59,7 @@ class User
             $this->username = $faker->userName;
             $this->profilePhoto = $faker->imageUrl();
             $this->coverPhoto = $faker->imageUrl();
-            $this->steamId = '765' . $faker->randomNumber(7, true) . $faker->randomNumber(7, true);;
+            $this->steamId = '765' . $faker->randomNumber(7, true) . $faker->randomNumber(7, true);
             $this->discordId = $faker->randomNumber();
         }
 

--- a/src/Walkway.php
+++ b/src/Walkway.php
@@ -10,6 +10,13 @@ use Truckspace\Walkway\Services\TruckspaceService;
 class Walkway
 {
     /**
+     * Determines if we should fake the response.
+     *
+     * @var bool
+     */
+    protected static $fake = false;
+
+    /**
      * Generate the URL for the path and base URL.
      *
      * @param  string  $path
@@ -28,6 +35,10 @@ class Walkway
      */
     public static function user(?Model $model = null): ?User
     {
+        if (self::$fake) {
+            return (new User(null, self::$fake));
+        }
+
         if (! $model && Auth::check()) {
             $model = Auth::user();
         }
@@ -39,5 +50,15 @@ class Walkway
         $user = TruckspaceService::getUser($model);
 
         return (new User($user));
+    }
+
+    /**
+     * Set the fake property to true.
+     *
+     * @return void
+     */
+    public static function fake()
+    {
+        self::$fake = true;
     }
 }


### PR DESCRIPTION
During PHPUnit tests we might not want to call the actual server. This allows us to run `Walkway::fake()` which will return fake data from the user model without calling the API.

Closes #2 