### PR TITLE
Improve how we fake data

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ $name = $user->username;
 <a name="faking-data"></a>
 ### Faking Data
 
-During unit tests, you may want to return fake data for the user model. This means that a call won't be made to the API server, but you will still get a value back from the attributes or methods. To use fake data you simply need to run the following method either at the beginning of your test or in your base test class.
+During unit tests, you may want to return fake data for the user model. This means that a call won't be made to our API, but you will still get a value back from the attributes or methods. To get fake data you simply need to call `Walkway::fake()` either at the beginning of your test or in your base test class.
 
 ```php
 <?php
@@ -255,6 +255,8 @@ public function test_a_username_is_a_string()
     $this->assertIsString($user->username);
 }
 ```
+
+> Note: in order for faking to work, your user MUST have a Truckspace ID set. This can also be a random number.
 
 ## Testing
 

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -61,9 +61,7 @@ class User
             $this->coverPhoto = $faker->imageUrl();
             $this->steamId = '765' . $faker->randomNumber(7, true) . $faker->randomNumber(7, true);
             $this->discordId = $faker->randomNumber();
-        }
-
-        if ($user) {
+        } elseif ($user) {
             $this->id = $user['id'];
             $this->username = $user['username'];
             $this->profilePhoto = $user['profile_photo'];

--- a/src/Walkway.php
+++ b/src/Walkway.php
@@ -14,7 +14,7 @@ class Walkway
      *
      * @var bool
      */
-    protected static $fake = false;
+    protected static $shouldFake = false;
 
     /**
      * Generate the URL for the path and base URL.
@@ -35,16 +35,16 @@ class Walkway
      */
     public static function user(?Model $model = null): ?User
     {
-        if (self::$fake) {
-            return (new User(null, self::$fake));
+        if (! $model && ! Auth::check()) {
+            return null;
         }
 
         if (! $model && Auth::check()) {
             $model = Auth::user();
         }
 
-        if (! $model && ! Auth::check()) {
-            return null;
+        if (self::$shouldFake && $model->getAttribute(config('laravel-walkway.columns.id'))) {
+            return (new User(null, self::$shouldFake));
         }
 
         $user = TruckspaceService::getUser($model);
@@ -59,6 +59,6 @@ class Walkway
      */
     public static function fake()
     {
-        self::$fake = true;
+        self::$shouldFake = true;
     }
 }


### PR DESCRIPTION
Before faking data, we now check that either a user model has been passed or the user is authenticated. The user model also have a `truckspace_id` set in order for fake data to be returned.