### PR TITLE
Add the ability to cache the user data forever

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ One advantage of using Walkway, is that it will automatically take care of cachi
 ],
 ```
 
+> Note: Setting the cache `ttl` to `null` or `-1`, will cache the user data _forever_ (until the cache is cleared or the key is removed).
+
 <a name="socialite-provider"></a>
 ### Socialite Provider
 

--- a/src/Services/TruckspaceService.php
+++ b/src/Services/TruckspaceService.php
@@ -32,11 +32,17 @@ class TruckspaceService
         }
 
         $key = config('laravel-walkway.cache.prefix') . $truckspaceId;
+        $ttl = config('laravel-walkway.cache.ttl');
 
-        return Cache::store($store)
-            ->remember($key, config('laravel-walkway.cache.ttl'), function () use ($user) {
+        if (! $ttl || $ttl === -1) {
+            return Cache::store($store)->rememberForever($key, function () use ($user) {
                 return self::getUserFromApi($user);
             });
+        }
+
+        return Cache::store($store)->remember($key, $ttl, function () use ($user) {
+            return self::getUserFromApi($user);
+        });
     }
 
     /**


### PR DESCRIPTION
Walkway automatically caches the user data returned from the Truckspace API. Users are currently able to determine how long the data should be cached for in seconds. However, it doesn't currently support caching the response forever.

This PR adds support for caching the user data forever by setting the `ttl` config setting to either `null` or `-1`.