### PR TITLE
Remove code coverage checks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,10 +4,7 @@
 # Ignore all test and documentation with "export-ignore".
 /.gitattributes     export-ignore
 /.gitignore         export-ignore
-/.travis.yml        export-ignore
 /phpunit.xml.dist   export-ignore
 /tests              export-ignore
 /.editorconfig      export-ignore
-/.php_cs.dist       export-ignore
 /.github            export-ignore
-/psalm.xml          export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,6 @@
 .idea
-.php_cs
-.php_cs.cache
 .phpunit.result.cache
-build
 composer.lock
-coverage
-docs
 phpunit.xml
-psalm.xml
 vendor
 .DS_Store

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,6 @@
     },
     "scripts": {
         "test": "vendor/bin/phpunit --colors=always",
-        "test-coverage": "vendor/bin/phpunit --coverage-html coverage",
         "test-format": "vendor/bin/phpcs src --standard=PSR12",
         "format": "vendor/bin/phpcbf src --standard=PSR12"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,17 +15,4 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <coverage>
-        <include>
-            <directory suffix=".php">./src</directory>
-        </include>
-        <report>
-            <html outputDirectory="build/coverage"/>
-            <text outputFile="build/coverage.txt"/>
-            <clover outputFile="build/logs/clover.xml"/>
-        </report>
-    </coverage>
-    <logging>
-        <junit outputFile="build/report.junit.xml"/>
-    </logging>
 </phpunit>


### PR DESCRIPTION
When we ran the test suite, we would automatically test the code coverage as well but this is no longer needed.