### PR TITLE
Add support for PHP 8 and older versions of Laravel

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ 7.4, 8.0 ]
-        laravel: [ ^8.0 ]
+        php: [ 7.3, 7.4, 8.0 ]
+        laravel: [ ^6.0, ^7.0, ^8.0 ]
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,41 +4,32 @@ on: [push, pull_request]
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
+
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest]
-        php: [7.4]
-        laravel: [8.*]
-        dependency-version: [prefer-lowest, prefer-stable]
-        include:
-          - laravel: 8.*
-            testbench: 6.*
+        php: [ 7.4, 8.0 ]
+        laravel: [ ^8.0 ]
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
+    name: P${{ matrix.php }} - L${{ matrix.laravel }}
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.composer/cache/files
-          key: dependencies-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
-
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
+          extensions: dom, curl, libxml, mbstring, zip
+          tools: composer:v2
           coverage: none
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+          composer require "illuminate/contracts=${{ matrix.laravel }}" --no-update
+          composer update --prefer-dist --no-interaction --no-progress
 
       - name: Execute tests
         run: |

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
         "laravel/socialite": "^5.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^5.0|^6.0",
-        "phpunit/phpunit": "^8.5.8|^9.3.3",
+        "orchestra/testbench": "^4.0|^5.0|^6.0",
+        "phpunit/phpunit": "^8.0|^9.3",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.4",
+        "php": "^7.4|^8.0",
         "ext-json": "*",
         "fakerphp/faker": "^1.9",
         "illuminate/support": "^8.7",

--- a/composer.json
+++ b/composer.json
@@ -15,15 +15,14 @@
         }
     ],
     "require": {
-        "php": "^7.4|^8.0",
-        "ext-json": "*",
+        "php": "^7.3|^8.0",
         "fakerphp/faker": "^1.9",
-        "illuminate/support": "^8.7",
+        "illuminate/support": "^6.0|^7.0|^8.0",
         "laravel/socialite": "^5.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.0",
-        "phpunit/phpunit": "^9.3.3",
+        "orchestra/testbench": "^5.0|^6.0",
+        "phpunit/phpunit": "^8.5.8|^9.3.3",
         "squizlabs/php_codesniffer": "^3.5"
     },
     "autoload": {


### PR DESCRIPTION
As the title says, this adds support for PHP 8 but also adds support for PHP 7.3, Laravel 6 and Laravel 7.