### PR TITLE
Add the identity scope by default

### DIFF
--- a/src/SocialiteProviders/TruckspaceProvider.php
+++ b/src/SocialiteProviders/TruckspaceProvider.php
@@ -9,6 +9,15 @@ use Laravel\Socialite\Two\User;
 class TruckspaceProvider extends AbstractProvider
 {
     /**
+     * The scopes being requested.
+     *
+     * @var array
+     */
+    protected $scopes = [
+        'identity',
+    ];
+
+    /**
      * Get the authentication URL for the provider.
      *
      * @param  string  $state


### PR DESCRIPTION
This will now add the `identity` scope by default.