### PR TITLE
Fix the scope separator

### DIFF
--- a/src/SocialiteProviders/TruckspaceProvider.php
+++ b/src/SocialiteProviders/TruckspaceProvider.php
@@ -18,6 +18,13 @@ class TruckspaceProvider extends AbstractProvider
     ];
 
     /**
+     * The separating character for the requested scopes.
+     *
+     * @var string
+     */
+    protected $scopeSeparator = ' ';
+
+    /**
      * Get the authentication URL for the provider.
      *
      * @param  string  $state


### PR DESCRIPTION
This fixes an issue when trying to use multiple scopes. Truckspace ID requires a space between scopes instead of a comma.